### PR TITLE
게시물 페이지네이션 쿼리 수정

### DIFF
--- a/src/authentication/auth.controller.ts
+++ b/src/authentication/auth.controller.ts
@@ -47,9 +47,9 @@ export class AuthController {
     try {
       // 카카오에서 토큰 받아오기
       console.log('code', code)  // 인가 코드 확인
-      const kakaoToken = await this.authService.getKakaoToken(code);
+      const kakaoToken = await this.authService.fetchKakaoToken(code);
       // 토큰을 카카오에게 전달한 후 유저 정보 받아오기
-      const kakaoUserInfo = await this.authService.getKakaoUserInfo(kakaoToken);
+      const kakaoUserInfo = await this.authService.fetchKakaoUserInfo(kakaoToken);
       // 우리 서버의 토큰 발행하기
       const token = await this.authService.oauthSignIn(kakaoUserInfo);
       // 토큰에 oauthProvider 정보 넣어주기

--- a/src/feed/feeds.controller.ts
+++ b/src/feed/feeds.controller.ts
@@ -17,13 +17,13 @@ export class FeedsController {
   // 모든 게시글 조회 (공개)
   @Get()
   getPublicFeeds() {
-    return this.feedsService.getPublicFeeds();
+    return this.feedsService.getPublicFeedsPaginated();
   }
 
   // 모든 게시글 조회 페이지네이션 (공개)
   @Get('pagination')
   async getPublicFeedsPagination(@Query('pageNumber', ParseIntPipe) pageNumber: number) {
-    return this.feedsService.getPublicFeedsPagination(pageNumber);
+    return this.feedsService.getPublicFeedsPaginated(pageNumber);
   }
 
   // 게시물 ID로 특정 게시물 조회 (공개)

--- a/src/feed/feeds.service.ts
+++ b/src/feed/feeds.service.ts
@@ -27,21 +27,16 @@ export class FeedsService {
     return this.feedExtractor.extractFeeds(feeds);
   }
 
-  // 모든 공개 게시물 페이지네이션
-  async getPublicFeedsPagination(pageNumber: number = 1) {
-    const pageSize = 9; // 한 페이지당 최대 게시물 수
-    const skip = (pageNumber - 1) * pageSize;
+  // 모든 공개 게시물 조회 (페이지네이션)
+  async getPublicFeedsPaginated(pageNumber: number = 1, pageSize: number = 9) {
     const criteria = {
       isPublic: true,
       $or: [{ deletedAt: null }, { deletedAt: { $exists: false } }],
     };
-
-    try {
-      const feeds = await this.feedModel.find(criteria).sort({ createdAt: -1 }).skip(skip).limit(pageSize).exec();
-      return this.feedExtractor.extractFeeds(feeds);
-    } catch (error) {
-      throw error;
-    }
+    const paginatedResult = await this.feedExtractor.getFeedPaginated(pageNumber, pageSize, criteria);
+    const extractedFeeds = await this.feedExtractor.extractFeeds(paginatedResult.feeds.data);
+    paginatedResult.feeds.data = extractedFeeds;
+    return paginatedResult;
   }
 
   // 게시물 ID로 특정 공개 게시물 조회하기

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import cors from 'cors';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  // app.use(cors.default());
-  app.use(
-    cors({
-      origin: '*',
-      credentials: true,
-    }),
-  );
+  app.enableCors({
+    origin: '*',
+    credentials: true,
+  });
 
   await app.listen(3000);
 }


### PR DESCRIPTION
페이지네이션 쿼리 수정

◆ 문제
- 기존 코드는 **두 개의 독립적인 요청을 보내는** 구조로, 이로 인해 **동시성 문제**가 발생할 수 있음.
- 즉, 한 요청이 보내진 후에 그 사이에 데이터베이스 내용이 변경된다면, 해당 변경 사항이 반영되지 않음.
→ 데이터 일관성에 영향을 줄 수 있음.
(실제로 데이터가 일관되게 로드되지 않는 것을 확인함.)

◆ 해결
- **aggregate** 집계함수의 **$facet** 쿼리를 사용함.
→ 동일한 데이터 세트를 동시에 처리

◆ 확인
DB에 공개 게시물(isPublic: true) 14개 중,
travelPlan이 null인 게시물 1개를 제외하고 13개 출력됨
pageNumber=1 : 9개
pageNumber=2 : 4개
변동 없이 정상적으로 출력됨.